### PR TITLE
fix(profile): モバイルでサイドバーがメインに被る不具合を修正

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -646,6 +646,9 @@ footer.cph .meta {
 .cv-grid { display: grid; grid-template-columns: 240px 1fr; gap: 64px; padding-top: 72px; padding-bottom: 96px; }
 @media (max-width: 1000px) { .cv-grid { grid-template-columns: 1fr; gap: 32px; padding-top: 48px; padding-bottom: 72px; } }
 .cv-side { position: sticky; top: 88px; align-self: start; min-width: 0; }
+/* In the stacked single-column layout the sticky sidebar would stay pinned and
+   overlap the (much taller) main content as it scrolls underneath. Disable sticky. */
+@media (max-width: 1000px) { .cv-side { position: static; top: auto; } }
 .cv-grid > * { min-width: 0; }
 .cv-side .portrait { width: 100%; aspect-ratio: 4/5; background: var(--paper-2); filter: grayscale(85%) contrast(1.05); margin-bottom: 20px; overflow: hidden; }
 .cv-side .portrait img { width: 100%; height: 100%; object-fit: cover; display: block; }


### PR DESCRIPTION
## 概要
/profile ページのモバイル幅でサイドバー（プロフィール画像・連絡先）がメインコンテンツに被る不具合を修正します。

## 原因
`.cv-side` は `position: sticky; top: 88px`。デスクトップでは 240px の独立カラムなので追従は意図通り。しかしモバイル幅（`max-width: 1000px`）で `.cv-grid` が単一カラムに縦積みされると、sticky のままサイドバーが画面上部に固定され、背の高いメインコンテンツがその下をスクロールして被ってしまう。

## 修正
モバイルのメディアクエリで `.cv-side` を `position: static` に戻し、通常フローで縦積みされるようにした。デスクトップ（>1000px）の挙動は不変。

```css
@media (max-width: 1000px) { .cv-side { position: static; top: auto; } }
```

## 検証
真の 375px ビューポート（iframe）で実測：
- 修正前: スクロール中（scrollY≥800）にサイドバーがメインと縦方向に重なる（overlap: true）
- 修正後: 全スクロール位置で overlap なし。横スクロールも発生なし。
- デスクトップ幅はメディアクエリ外なので影響なし。